### PR TITLE
Provide a way to allow reverse proxies & https

### DIFF
--- a/static/themes/basic/base.css
+++ b/static/themes/basic/base.css
@@ -5,7 +5,7 @@
  - rust: #7D1921
  - navy: #2E3959
 */
-@import url(http://fonts.googleapis.com/css?family=Quicksand:300,400,700);
+@import url(https://fonts.googleapis.com/css?family=Quicksand:300,400,700);
 
 body {
 	margin:0px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,7 +19,7 @@ $code:
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>${content.title + (" - "+gv.sd['name'] if gv.sd['name'] != "OpenSprinkler Pi" else "")}</title>
     <link href="/static/images/favicon.ico" rel="icon" type="image/x-icon">
-    <link href="${gv.baseurl}/static/themes/${gv.sd['theme']}/base.css" rel="stylesheet" type="text/css"/>
+    <link href="/static/themes/${gv.sd['theme']}/base.css" rel="stylesheet" type="text/css"/>
     <style type="text/css">
         .bluebg {background-color:lightblue;}
         .opOn, .wlOn, .rsOff {color:green;}
@@ -49,7 +49,7 @@ $code:
         td.stationNumber, td.stationShow, td.stationIgnore, td.stationMaster {text-align:center;}
         td.stationName {text-align:left; padding-left:1em;}
     </style>
-    <script src="${gv.baseurl}/static/scripts/jquery-1.8.2.min.js"></script>
+    <script src="/static/scripts/jquery-1.8.2.min.js"></script>
     <script>
         // Variables set server-side
         var devTzOffset = ${gv.tz_offset}*1000;
@@ -105,9 +105,9 @@ $code:
                 });
             });
     </script>
-    <script src="${gv.baseurl}/static/scripts/behaviors.js"></script>
-    <script src="${gv.baseurl}/static/scripts/schedule.js"></script>
-    <script src="${gv.baseurl}/static/scripts/intervalSelect.js"></script>
+    <script src="/static/scripts/behaviors.js"></script>
+    <script src="/static/scripts/schedule.js"></script>
+    <script src="/static/scripts/intervalSelect.js"></script>
 </head>
 <body>
     <div class="content">

--- a/web/application.py
+++ b/web/application.py
@@ -344,13 +344,16 @@ class application:
         ctx.output = ''
         ctx.environ = ctx.env = env
         ctx.host = env.get('HTTP_HOST')
-
-        if env.get('wsgi.url_scheme') in ['http', 'https']:
+	
+	if env.get('HTTP_X_FORWARDED_PROTO') in ['http', 'https']:
+            ctx.protocol = env.get('HTTP_X_FORWARDED_PROTO')	
+        elif env.get('wsgi.url_scheme') in ['http', 'https']:
             ctx.protocol = env['wsgi.url_scheme']
         elif env.get('HTTPS', '').lower() in ['on', 'true', '1']:
-            ctx.protocol = 'https'
-        else:
+            ctx.protocol = 'https' 
+	else:
             ctx.protocol = 'http'
+
         ctx.homedomain = ctx.protocol + '://' + env.get('HTTP_HOST', '[unknown]')
         ctx.homepath = os.environ.get('REAL_SCRIPT_NAME', env.get('SCRIPT_NAME', ''))
         ctx.home = ctx.homedomain + ctx.homepath


### PR DESCRIPTION
## explanation
I run nginx at home to proxy all of my web traffic, and drop an ssl in front of everything. 

if you drop an SSL nginx reverse proxy infront of OSPi two defects occur.

1. you are redirected to the `http://<hostname>/login` instead of `https://<hostname>/login`
2. some/most of the static assets are loaded via `http://`, when really they should be loaded with `//`, this will allow them to be loaded for both https and http.


## Steps to reproduce
1. put an ssl nginx reverse proxy in front of the OSPi interface.
2. visit the proxied url (in my case https://sprinkler.domain.com), it will redirect to `http://<hostname>/login`
3. force that URL to be `https://<hostname>/login` and none of the static assets will load.

I would be happy to fork, and attempt to fix these two things and issue a PR.

## potential root cause
After digging a bit I think this block is whats causing the issues, `wsgi.url_scheme` is always `http` because it doesn't know how to interpret the `X-Forwarded-Proto` header. 

```python
        if env.get('wsgi.url_scheme') in ['http', 'https']:
            ctx.protocol = env['wsgi.url_scheme']
        elif env.get('HTTPS', '').lower() in ['on', 'true', '1']:
            ctx.protocol = 'https'
        else:
            ctx.protocol = 'http'
```

## potential fix
1. for the redirect issue, adding a conditional statement to check for the `X-Forwarded-Proto` header should work sufficiently. 
2. For the static assets, i'd think moving them to absolute paths instead of `http://....` would work fine as well.
3. for google fonts in the base.css, just moving that to use `https` by default should work fine

**web/application.py**
```python
        if env.get('HTTP_X_FORWARDED_PROTO') in ['http', 'https']:
            ctx.protocol = env.get('HTTP_X_FORWARDED_PROTO')
        elif env.get('wsgi.url_scheme') in ['http', 'https']:
            ctx.protocol = env['wsgi.url_scheme']
        elif env.get('HTTPS', '').lower() in ['on', 'true', '1']:
            ctx.protocol = 'https'
        else:
            ctx.protocol = 'http'
```

**templates/base.html**
```
    <link href="/static/them......
```